### PR TITLE
Replaces `CaptureBinary` with `rpicam-vid` instead of `libcamera-vid`.

### DIFF
--- a/SLS4All.Compact.PrinterApp/appsettings.Inova-RaspberryPi5-libcamera.toml
+++ b/SLS4All.Compact.PrinterApp/appsettings.Inova-RaspberryPi5-libcamera.toml
@@ -1,5 +1,6 @@
 ﻿[MjpegDeviceCamera] # [monitored]
-CaptureBinary = "/usr/bin/libcamera-vid"
+# CaptureBinary = "/usr/bin/libcamera-vid"
+CaptureBinary = "/usr/bin/rpicam-vid"
 CaptureArgs = "-t 0 -o - --width 600 --height 650 --codec mjpeg --saturation 0.5 --awbgains 1,1 --ev 0 --awb auto --analoggain 1 --sharpness 4 --framerate 12 --roi 0.18,0.0575,0.57,0.85 --exposure sport --nopreview --brightness {{brightness}} --contrast {{contrast}}"
 Rotation = 1
 MostlyEmptyPixelValueThreshold = 64


### PR DESCRIPTION
Comments out the `/usr/bin/libcamera-vid` and replaces with `/usr/bin/rpicam-vid`.
For both Ubuntu and Raspi OS, I ran into an issue where the setting for `/usr/bin/libcamera-vid` doesn't work.
I think that the[ `libcamera` has been replaced by `rpicam` ](https://www.raspberrypi.com/documentation/computers/camera_software.html#rpicam-apps)and have found that using that library seems to work right out of the box.

Leaves original line commented for cases to switch back to libcamera-vid.